### PR TITLE
remove="true" option should not fail when no layer correspond

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,8 +4,8 @@ Changelog
 2.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Add support for calling many times remove in export (ie:even when no corresponding layer is registred, remove option should not throw exception).
+  [toutpt]
 
 2.1.1 (2011-11-24)
 ------------------

--- a/plone/browserlayer/exportimport.py
+++ b/plone/browserlayer/exportimport.py
@@ -66,7 +66,10 @@ class BrowserLayerXMLAdapter(XMLAdapterBase):
             if child.nodeName.lower() == 'layer':
                 name = child.getAttribute('name')
                 if child.getAttribute('remove'):
-                    unregister_layer(name, site_manager=self.context)
+                    try:
+                        unregister_layer(name, site_manager=self.context)
+                    except KeyError, e:
+                        self._logger.info(e)
                     continue
                 interface = _resolveDottedName(child.getAttribute('interface'))
                 register_layer(interface, name, site_manager=self.context)

--- a/plone/browserlayer/tests/profiles/uninstall/browserlayer.xml
+++ b/plone/browserlayer/tests/profiles/uninstall/browserlayer.xml
@@ -1,4 +1,7 @@
 <layers>
     <layer name="plone.browserlayer.tests"
            remove="true" />
+    <!-- remove not existing should not doing more than a log -->
+    <layer name="plone.browserlayer.tests.notexisting"
+           remove="true" />
 </layers>


### PR DESCRIPTION
Add support for calling many times remove in export (ie:even when no corresponding layer is registred, remove option should not throw exception).
