### PR TITLE
Fixed test when using Zope 4.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-2.1.8 (unreleased)
+2.2.0 (unreleased)
 ------------------
 
 Breaking changes:
@@ -14,7 +14,7 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fixed test when using Zope 4.  [maurits]
 
 
 2.1.7 (2016-11-01)

--- a/plone/browserlayer/README.rst
+++ b/plone/browserlayer/README.rst
@@ -14,8 +14,7 @@ Before the product is installed, we cannot view this:
     >>> from plone.testing import z2
 
     >>> from plone.testing.z2 import Browser
-    >>> with z2.zopeApp() as app:
-    ...     browser = Browser(app)
+    >>> browser = Browser(layer['app'])
     >>> browser.open(layer['portal'].absolute_url() + '/@@layer-test-view')
     Traceback (most recent call last):
     ...
@@ -34,6 +33,8 @@ use GenericSetup.
     >>> utils.register_layer(IMyProductLayer, name='my.product')
     >>> IMyProductLayer in utils.registered_layers()
     True
+    >>> import transaction;
+    >>> transaction.commit()
 
 And if we now traverse over the site root and render the view, it should be
 there.
@@ -56,7 +57,7 @@ It is also possible to uninstall a layer:
     >>> utils.unregister_layer(name='my.product')
     >>> IMyProductLayer in utils.registered_layers()
     False
-
+    >>> transaction.commit()
     >>> browser.open(layer['portal'].absolute_url() + '/@@layer-test-view')
     Traceback (most recent call last):
     ...

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-version = '2.1.8.dev0'
+version = '2.2.0.dev0'
 
 setup(
     name='plone.browserlayer',


### PR DESCRIPTION
The README.rst test was instantiating an app, where it should just use the app from the layer.
Needed to add two transaction commits as well in this functional test.